### PR TITLE
:dash: add speed controller keyboard shortcuts

### DIFF
--- a/audio-timestamper/README.md
+++ b/audio-timestamper/README.md
@@ -20,9 +20,20 @@ To install, do the same thing you do for any roam/js script.
 
 ```javascript
  window.audioTimestamperConfig = {
-    enableClickAndPlay: true,
-    enableSpeedController: true,
-    speed: [0.5, 1.0, 1.5, 2.0]
+   enableClickAndPlay: false,
+
+   increaseSpeedKey: 'd',
+   decreaseSpeedKey: 's',
+   rewindKey: 'z',
+   advanceKey: 'x',
+   resetSpeedKey: 'r',
+   preferredSpeedKey: 'G',
+
+   increaseSpeed: 0.5,
+   decreaseSpeed: 0.5,
+   rewind: 10,
+   advance: 10,
+   preferredSpeed: 1.2,
  };
 
  var s = document.createElement("script");

--- a/audio-timestamper/README.md
+++ b/audio-timestamper/README.md
@@ -20,8 +20,10 @@ To install, do the same thing you do for any roam/js script.
 
 ```javascript
  window.audioTimestamperConfig = {
-   enableClickAndPlay: true
- }; 
+    enableClickAndPlay: true,
+    enableSpeedController: true,
+    speed: [0.5, 1.0, 1.5, 2.0]
+ };
 
  var s = document.createElement("script");
  s.type = "text/javascript";

--- a/audio-timestamper/README.md
+++ b/audio-timestamper/README.md
@@ -2,6 +2,20 @@
 
 ![](https://user-images.githubusercontent.com/78351950/106455697-e355f000-64cf-11eb-9e60-82763f9d2ffd.png)
 
+
+## Speed Control Shortcuts
+
+| Name            | Default Key | Default Value |
+|-----------------|-------------|---------------|
+| Increase speed  | alt+shift+d | 0.5           |
+| Decrease speed  | alt+shift+s | 0.5           |
+| Rewind          | alt+shift+z | 10            |
+| Advance         | alt+shft+x  | 10            |
+| Reset           | alt+shift+r | -             |
+| Preferred speed | alt+shift+g | 1.2           |
+
+In macOS, you can use 'option' instead of 'alt'.
+
 ## Installation
 
 To install, do the same thing you do for any roam/js script.
@@ -23,12 +37,12 @@ To install, do the same thing you do for any roam/js script.
    enableClickAndPlay: false,
    enableKeyShortCuts: true,
 
-   increaseSpeedKey: 'd',
-   decreaseSpeedKey: 's',
-   rewindKey: 'z',
-   advanceKey: 'x',
-   resetSpeedKey: 'r',
-   preferredSpeedKey: 'G',
+   increaseSpeedKey: 'alt+shift+d',
+   decreaseSpeedKey: 'alt+shift+s',
+   rewindKey: 'alt+shift+z',
+   advanceKey: 'alt+shift+x',
+   resetSpeedKey: 'alt+shift+r',
+   preferredSpeedKey: 'alt+shift+g',
 
    increaseSpeed: 0.5,
    decreaseSpeed: 0.5,

--- a/audio-timestamper/README.md
+++ b/audio-timestamper/README.md
@@ -5,6 +5,8 @@
 
 ## Speed Control Shortcuts
 
+**This is only available for the audio that is playing. If there are multiple playing audio tags, this short cuts will only work for the first audio tag.**
+
 | Name            | Default Key | Default Value |
 |-----------------|-------------|---------------|
 | Increase speed  | alt+shift+d | 0.5           |

--- a/audio-timestamper/README.md
+++ b/audio-timestamper/README.md
@@ -21,6 +21,7 @@ To install, do the same thing you do for any roam/js script.
 ```javascript
  window.audioTimestamperConfig = {
    enableClickAndPlay: false,
+   enableKeyShortCuts: true,
 
    increaseSpeedKey: 'd',
    decreaseSpeedKey: 's',

--- a/audio-timestamper/audio-timestamper.js
+++ b/audio-timestamper/audio-timestamper.js
@@ -3,12 +3,12 @@
         enableClickAndPlay: false,
         enableKeyShortCuts: true,
 
-        increaseSpeedKey: 'd',
-        decreaseSpeedKey: 's',
-        rewindKey: 'z',
-        advanceKey: 'x',
-        resetSpeedKey: 'r',
-        preferredSpeedKey: 'G',
+        increaseSpeedKey: 'alt+shift+d',
+        decreaseSpeedKey: 'alt+shift+s',
+        rewindKey: 'alt+shift+z',
+        advanceKey: 'alt+shift+x',
+        resetSpeedKey: 'alt+shift+r',
+        preferredSpeedKey: 'alt+shift+g',
 
         increaseSpeed: 0.5,
         decreaseSpeed: 0.5,

--- a/audio-timestamper/audio-timestamper.js
+++ b/audio-timestamper/audio-timestamper.js
@@ -1,6 +1,7 @@
 (function (global) {
     const defaultConfig = {
         enableClickAndPlay: false,
+        enableKeyShortCuts: true,
 
         increaseSpeedKey: 'd',
         decreaseSpeedKey: 's',
@@ -90,6 +91,12 @@
       };
 
       const mouseTrapReady = setInterval(() => {
+        if (!config.enableKeyShortCuts) {
+          clearInterval(mouseTrapReady);
+          log("disabled key shourtcuts");
+          return;
+        }
+
         log("in mouseTrapReady");
         if (Mousetrap === undefined) return;
         log("found: mouseTrapReady");

--- a/audio-timestamper/audio-timestamper.js
+++ b/audio-timestamper/audio-timestamper.js
@@ -1,5 +1,11 @@
 (function (global) {
-    const config = global.audioTimestamperConfig;
+    const defaultConfig = {
+        enableClickAndPlay: false,
+        enableSpeedController: false,
+        speed: [0.5, 1.0, 1.5, 2.0]
+    };
+    const config = {...defaultConfig, ...global.audioTimestamperConfig};
+
     const activate = () => {
         Array.from(document.getElementsByTagName('AUDIO'))
         .forEach(el => {
@@ -8,10 +14,29 @@
           }
           const block = el.closest('.roam-block-container');
           addTimestampButtons(block, el);
+
+          if (config.enableSpeedController) {
+            addSpeedControlButtons(block, el);
+          }
         });
     };
 
     const getControlButton = (block) => block.parentElement.querySelector('.audio-timestamp-control');
+    const getSpeedControlButton = (block) => block.parentElement.querySelector('.audio-speed-control');
+
+    const addSpeedControlButtons = (block, el) => {
+        if (block.children.length < 2) return null;
+
+        if (getSpeedControlButton(block) !== null) {
+            return null;
+        }
+
+        const parent = document.createElement('div');
+        config.speed.forEach(speed => addSpeedControlButton(parent, el, speed));
+
+        const closestMainBlock = el.closest('.rm-block-main');
+        closestMainBlock.parentElement.insertBefore(parent, closestMainBlock.nextSibling);
+    };
 
     const addTimestampButtons = (block, el) => {
         if (block.children.length < 2) return null;
@@ -42,6 +67,17 @@
         button.style.borderRadius = '50%';
         button.addEventListener('click', fn);
         block.parentElement.insertBefore(button, block);
+      };
+
+      const addSpeedControlButton = (parent, el, speed) => {
+        const button = document.createElement('button');
+        button.innerText = speed.toFixed(1);
+        button.classList.add('audio-speed-control');
+        button.style.borderRadius = '50%';
+        button.addEventListener('click', () => {
+            el.playbackRate = speed;
+        });
+        parent.insertBefore(button, parent.nextSibling);
       };
 
       const getTimestamp = (block) => {


### PR DESCRIPTION
| Name            | Default Key | Default Value |
|-----------------|-------------|---------------|
| Increase speed  | alt+shift+d | 0.5           |
| Decrease speed  | alt+shift+s | 0.5           |
| Rewind          | alt+shift+z | 10            |
| Advance         | alt+shft+x  | 10            |
| Reset           | alt+shift+r | -             |
| Preferred speed | alt+shift+g | 1.2           |


I added speed controller short cuts for audio tag. This is only valid for audio being played.

**This is only available for the audio that is playing. If there are multiple playing audio tags, this short cuts will only work for the first audio tag.**

---

Let's try it.

```javascript
 window.audioTimestamperConfig = {
    enableClickAndPlay: false,
    enableKeyShortCuts: true,
    
    increaseSpeedKey: 'alt+shift+d',
    decreaseSpeedKey: 'alt+shift+s',
    rewindKey: 'alt+shift+z',
    advanceKey: 'alt+shift+x',
    resetSpeedKey: 'alt+shift+r',
    preferredSpeedKey: 'alt+shift+g',
    
    increaseSpeed: 0.5,
    decreaseSpeed: 0.5,
    rewind: 10,
    advance: 10,
    preferredSpeed: 1.2,
 };

 var s = document.createElement("script");
 s.type = "text/javascript";
 s.src = "https://cdn.jsdelivr.net/gh/serizawa-jp/roamkit@60a8b77a42b9abcdb6470a704d0072e517d187b7/audio-timestamper/audio-timestamper.js";
 document.getElementsByTagName("head")[0].appendChild(s);
```